### PR TITLE
add Trace to statsy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+
+# Emacs
+*~

--- a/index.js
+++ b/index.js
@@ -233,6 +233,14 @@ Client.prototype.decr = function(name, val, tags){
   this.count(name, -val, null, tags);
 };
 
+/**
+ * Creates a trace object that generates stats on this client.
+ *
+ * @param {String} name The name of the new trace, prefix for all its stats.
+ * @param {Array} [tags] The default tags set to all stats of the trace.
+ * @param {Date} [now] The start time of the trace
+ */
+
 Client.prototype.trace = function(name, tags, now){
   return new Trace(this, name, tags, now);
 };

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var assert = require('assert');
 var dgram = require('dgram');
 var net = require('net');
 var url = require('url');
+var Trace = require('./trace');
 
 /**
  * Expose `Client`.
@@ -182,7 +183,7 @@ Client.prototype.histogram = function(name, val, tags){
   }
 
   debug('histogram %j %s', name, val);
-  this.write(name + ':' + val + '|ms', tags);
+  this.write(name + ':' + val + '|h', tags);
 };
 
 /**
@@ -230,4 +231,8 @@ Client.prototype.incr = function(name, val, tags){
 Client.prototype.decr = function(name, val, tags){
   if (null == val) val = 1;
   this.count(name, -val, null, tags);
+};
+
+Client.prototype.trace = function(name, tags, now){
+  return new Trace(this, name, tags, now);
 };

--- a/test.js
+++ b/test.js
@@ -84,7 +84,7 @@ describe('decr', function(){
 
 describe('trace', function(){
   it('should write an empty trace', function(){
-    var trace = stats.trace('key', { hello: 'world' }, new Date(1000));
+    var trace = stats.trace('key', ['hello:world'], new Date(1000));
     trace.complete(new Date(2000));
     assert.deepEqual(args, [
       ['key.seconds:1|h|#hello:world,step:request'],
@@ -92,11 +92,11 @@ describe('trace', function(){
     ]);
   });
 
-  it('shoudl write a trace with a couple of stats', function(){
-    var trace = stats.trace('key', { hello: 'world' }, new Date(1000));
-    trace.step('A', { tag: 'a' }, new Date(1100));
-    trace.step('B', { tag: 'b' }, new Date(1300));
-    trace.step('C', { tag: 'c' }, new Date(1600));
+  it('should write a trace with a couple of stats', function(){
+    var trace = stats.trace('key', ['hello:world'], new Date(1000));
+    trace.step('A', ['tag:a'], new Date(1100));
+    trace.step('B', ['tag:b'], new Date(1300));
+    trace.step('C', ['tag:c'], new Date(1600));
     trace.complete(new Date(2000));
     assert.deepEqual(args, [
       ['key.seconds:0.1|h|#hello:world,tag:a,step:A'],

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 
 var assert = require('assert');
 var statsy = require('./');
+var Trace = require('./trace')
 var args;
 
 beforeEach(function(){
@@ -83,6 +84,10 @@ describe('decr', function(){
 });
 
 describe('trace', function(){
+  it('should throw an error if the trace name is not specified', function(){
+    assert.throws(stats.trace, Error, 'createing a trace with no name should throw an error');
+  });
+
   it('should write an empty trace', function(){
     var trace = stats.trace('key', ['hello:world'], new Date(1000));
     trace.complete(new Date(2000));
@@ -104,6 +109,31 @@ describe('trace', function(){
       ['key.seconds:0.3|h|#hello:world,tag:c,step:C'],
       ['key.seconds:1|h|#hello:world,step:request'],
       ['key.count:1|c|#hello:world']
+    ]);
+  });
+
+  it('should write a trace with default tags and date', function(){
+    Trace.now = function() { return new Date(1000) };
+    var trace = stats.trace('key');
+
+    Trace.now = function() { return new Date(1100) };
+    trace.step('A');
+
+    Trace.now = function() { return new Date(1300) };
+    trace.step('B');
+
+    Trace.now = function() { return new Date(1600) };
+    trace.step('C');
+
+    Trace.now = function() { return new Date(2000) };
+    trace.complete();
+
+    assert.deepEqual(args, [
+      ['key.seconds:0.1|h|#step:A'],
+      ['key.seconds:0.2|h|#step:B'],
+      ['key.seconds:0.3|h|#step:C'],
+      ['key.seconds:1|h|#step:request'],
+      ['key.count:1|c|#'],
     ]);
   });
 });

--- a/test.js
+++ b/test.js
@@ -82,3 +82,28 @@ describe('decr', function(){
   })
 });
 
+describe('trace', function(){
+  it('should write an empty trace', function(){
+    var trace = stats.trace('key', { hello: 'world' }, new Date(1000));
+    trace.complete(new Date(2000));
+    assert.deepEqual(args, [
+      ['key.seconds:1|h|#hello:world,step:request'],
+      ['key.count:1|c|#hello:world']
+    ]);
+  });
+
+  it('shoudl write a trace with a couple of stats', function(){
+    var trace = stats.trace('key', { hello: 'world' }, new Date(1000));
+    trace.step('A', { tag: 'a' }, new Date(1100));
+    trace.step('B', { tag: 'b' }, new Date(1300));
+    trace.step('C', { tag: 'c' }, new Date(1600));
+    trace.complete(new Date(2000));
+    assert.deepEqual(args, [
+      ['key.seconds:0.1|h|#hello:world,tag:a,step:A'],
+      ['key.seconds:0.2|h|#hello:world,tag:b,step:B'],
+      ['key.seconds:0.3|h|#hello:world,tag:c,step:C'],
+      ['key.seconds:1|h|#hello:world,step:request'],
+      ['key.count:1|c|#hello:world']
+    ]);
+  });
+});

--- a/trace.js
+++ b/trace.js
@@ -12,7 +12,7 @@ function Trace(client, name, tags, now) {
   this.name = name;
   this.tags = tags;
   this.start = now;
-  this.items = [ ];
+  this.steps = [ ];
 }
 
 Trace.prototype.step = function(step, tags, now) {
@@ -25,7 +25,7 @@ Trace.prototype.step = function(step, tags, now) {
   }
 
   tags.push('step:' + step);
-  this.items.push({ tags: tags, time: now });
+  this.steps.push({ tags: tags, time: now });
 };
 
 Trace.prototype.complete = function(now) {
@@ -34,7 +34,7 @@ Trace.prototype.complete = function(now) {
   var start = this.start;
   var ptime = this.start;
   var stats = this.client;
-  var items = this.items;
+  var steps = this.steps;
   var tags = this.tags;
 
   if (!stats) {
@@ -45,7 +45,7 @@ Trace.prototype.complete = function(now) {
     now = new Date;
   }
 
-  items.forEach(function(item) {
+  steps.forEach(function(item) {
     stats.histogram(timer, seconds(ptime, item.time), tags.concat(item.tags));
     ptime = item.time;
   });

--- a/trace.js
+++ b/trace.js
@@ -1,7 +1,7 @@
 
 function Trace(client, name, tags, now) {
   if (!tags) {
-    tags = { };
+    tags = [ ];
   }
 
   if (!now) {
@@ -10,21 +10,20 @@ function Trace(client, name, tags, now) {
 
   this.client = client;
   this.name = name;
-  this.tags = tagsArray(tags);
+  this.tags = tags;
   this.start = now;
   this.items = [ ];
 }
 
 Trace.prototype.step = function(step, tags, now) {
   if (!tags) {
-    tags = { };
+    tags = [ ];
   }
 
   if (!now) {
     now = new Date;
   }
 
-  tags = tagsArray(tags);
   tags.push('step:' + step);
   this.items.push({ tags: tags, time: now });
 };
@@ -56,16 +55,6 @@ Trace.prototype.complete = function(now) {
 
   this.client = null;
 };
-
-function tagsArray(tags) {
-  var array = [ ];
-
-  Object.keys(tags).forEach(function(key) {
-    array.push(key + ':' + tags[key]);
-  });
-
-  return array;
-}
 
 function seconds(from, to) {
   return (to.getTime() - from.getTime()) / 1000.0;

--- a/trace.js
+++ b/trace.js
@@ -45,9 +45,9 @@ Trace.prototype.complete = function(now) {
     now = new Date;
   }
 
-  steps.forEach(function(item) {
-    stats.histogram(timer, seconds(ptime, item.time), tags.concat(item.tags));
-    ptime = item.time;
+  steps.forEach(function(step) {
+    stats.histogram(timer, seconds(ptime, step.time), tags.concat(step.tags));
+    ptime = step.time;
   });
 
   stats.histogram(timer, seconds(start, now), tags.concat('step:request'));

--- a/trace.js
+++ b/trace.js
@@ -1,11 +1,15 @@
 
 function Trace(client, name, tags, now) {
+  if (!name) {
+    throw new Error("traces cannot be created without a name")
+  }
+
   if (!tags) {
     tags = [ ];
   }
 
   if (!now) {
-    now = new Date;
+    now = Trace.now();
   }
 
   this.client = client;
@@ -21,7 +25,7 @@ Trace.prototype.step = function(step, tags, now) {
   }
 
   if (!now) {
-    now = new Date;
+    now = Trace.now();
   }
 
   tags.push('step:' + step);
@@ -38,11 +42,11 @@ Trace.prototype.complete = function(now) {
   var tags = this.tags;
 
   if (!stats) {
-    throw new Error("Trace.complete: called more than once");
+    throw new Error(this.name + ": Trace.complete called more than once");
   }
 
   if (!now) {
-    now = new Date;
+    now = Trace.now();
   }
 
   steps.forEach(function(step) {
@@ -55,6 +59,10 @@ Trace.prototype.complete = function(now) {
 
   this.client = null;
 };
+
+Trace.now = function() {
+  return new Date;
+}
 
 function seconds(from, to) {
   return (to.getTime() - from.getTime()) / 1000.0;

--- a/trace.js
+++ b/trace.js
@@ -1,0 +1,74 @@
+
+function Trace(client, name, tags, now) {
+  if (!tags) {
+    tags = { };
+  }
+
+  if (!now) {
+    now = new Date;
+  }
+
+  this.client = client;
+  this.name = name;
+  this.tags = tagsArray(tags);
+  this.start = now;
+  this.items = [ ];
+}
+
+Trace.prototype.step = function(step, tags, now) {
+  if (!tags) {
+    tags = { };
+  }
+
+  if (!now) {
+    now = new Date;
+  }
+
+  tags = tagsArray(tags);
+  tags.push('step:' + step);
+  this.items.push({ tags: tags, time: now });
+};
+
+Trace.prototype.complete = function(now) {
+  var counter = this.name + '.count';
+  var timer = this.name + '.seconds';
+  var start = this.start;
+  var ptime = this.start;
+  var stats = this.client;
+  var items = this.items;
+  var tags = this.tags;
+
+  if (!stats) {
+    throw new Error("Trace.complete: called more than once");
+  }
+
+  if (!now) {
+    now = new Date;
+  }
+
+  items.forEach(function(item) {
+    stats.histogram(timer, seconds(ptime, item.time), tags.concat(item.tags));
+    ptime = item.time;
+  });
+
+  stats.histogram(timer, seconds(start, now), tags.concat('step:request'));
+  stats.incr(counter, 1, tags);
+
+  this.client = null;
+};
+
+function tagsArray(tags) {
+  var array = [ ];
+
+  Object.keys(tags).forEach(function(key) {
+    array.push(key + ':' + tags[key]);
+  });
+
+  return array;
+}
+
+function seconds(from, to) {
+  return (to.getTime() - from.getTime()) / 1000.0;
+}
+
+module.exports = Trace;


### PR DESCRIPTION
@calvinfo 
@yields 

Follow up of the PR on api-app, adds the `.trace` method.

Please let me know if anything should be changed.