### PR TITLE
add buffering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */

--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ Client.prototype.write = function(msg, tags){
     }
     this.buffer += msg;
     this.buffer += '\n';
+    return;
   }
 
   this.send(msg);


### PR DESCRIPTION
This PR adds support for buffering stats up to a buffer size limit. Buffering is disabled by default to avoid changing the existing behavior.

Please take a look and let me know if something should be changed.

I'm making this change to address issues we have in production because some busy node services are generating so many UDP packets that we're dropping metrics.