### PR TITLE
Add flushAfter property and logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ Client.prototype.send = function(msg){
  */
 
 Client.prototype.write = function(msg, tags){
-  var doNotSend = false;
+  var sendMsg = true;
   var alreadyAddedToBuffer = false;
 
   if (this.prefix) msg = this.prefix + '.' + msg;
@@ -106,7 +106,7 @@ Client.prototype.write = function(msg, tags){
     this.buffer += msg;
     this.buffer += '\n';
     alreadyAddedToBuffer = true;
-    doNotSend = true;
+    sendMsg = false;
   }
 
   // Exceeds flushAfter timeout
@@ -126,10 +126,10 @@ Client.prototype.write = function(msg, tags){
       this.flushScheduled = true;
     }
 
-    doNotSend = true;
+    sendMsg = false;
   }
 
-  if (!doNotSend) this.send(msg);
+  if (sendMsg) this.send(msg);
 };
 
 /**

--- a/test.js
+++ b/test.js
@@ -49,12 +49,10 @@ describe('write', function(){
     stats.flushAfter = 5000;
     stats.bufferSize = 30000;
     stats.write('key:1|c', ['tag:local']);
-    assert.deepEqual(args, []);
+    assert.deepEqual(args, []); // Empty before flush.
 
     setTimeout(function(){
-      stats.write('key:1|c', ['tag:local']);
       assert.deepEqual(args, [
-        'key:1|c|#tag:local',
         'key:1|c|#tag:local'
       ]);
       done();

--- a/test.js
+++ b/test.js
@@ -44,6 +44,22 @@ describe('write', function(){
       'key:1|c|#tag:global,tag:local'
     ]);
   });
+
+  it('should flush if flushAfter is exceeded', function(done){
+    stats.flushAfter = 5000;
+    stats.bufferSize = 30000;
+    stats.write('key:1|c', ['tag:local']);
+    assert.deepEqual(args, []);
+
+    setTimeout(function(){
+      stats.write('key:1|c', ['tag:local']);
+      assert.deepEqual(args, [
+        'key:1|c|#tag:local',
+        'key:1|c|#tag:local'
+      ]);
+      done();
+    }, 6000)
+  }).timeout(6500);
 });
 
 describe('incr', function(){


### PR DESCRIPTION
This is a quick, rough implementation of adding a flushAfter method to our stats library. One improvement I could make is to instead set a timeout to call .flush() after X milliseconds instead of waiting for another call to "push" out the buffer. However, this should work for the large majority of cases.