### PR TITLE
Node 10 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,29 @@
 version: 2
 jobs:
-  build:
+  node-10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-10-{{ checksum "package-lock.json" }}
+      - run: npm install
+      - save_cache:
+          key: dependency-cache-10-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
+      - run: npm test
+
+  node-12:
     docker:
       - image: circleci/node:12
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-12-{{ checksum "package-lock.json" }}
       - run: npm install
       - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-12-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
-      - run: ./node_modules/.bin/nyc ./node_modules/.bin/ava
+      - run: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,31 +2,31 @@ version: 2
 jobs:
   node-10:
     docker:
-      - image: circleci/node:10
+    - image: circleci/node:10
     steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-10-{{ checksum "package-lock.json" }}
-      - run: npm install
-      - save_cache:
-          key: dependency-cache-10-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-      - run: npm test
+    - checkout
+    - restore_cache:
+        key: dependency-cache-10-{{ checksum "package-lock.json" }}
+    - run: npm install
+    - save_cache:
+        key: dependency-cache-10-{{ checksum "package-lock.json" }}
+        paths:
+        - ./node_modules
+    - run: npm test
 
   node-12:
     docker:
-      - image: circleci/node:12
+    - image: circleci/node:12
     steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-12-{{ checksum "package-lock.json" }}
-      - run: npm install
-      - save_cache:
-          key: dependency-cache-12-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-      - run: npm test
+    - checkout
+    - restore_cache:
+        key: dependency-cache-12-{{ checksum "package-lock.json" }}
+    - run: npm install
+    - save_cache:
+        key: dependency-cache-12-{{ checksum "package-lock.json" }}
+        paths:
+        - ./node_modules
+    - run: npm test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,10 @@ jobs:
           paths:
             - ./node_modules
       - run: npm test
+
+workflows:
+  version: 2
+  run:
+    jobs:
+    - node-10
+    - node-12

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
+.nyc_output/
 
 # Emacs
 *~
+

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ class Client extends EventEmitter {
     this.buffer = ''
     this.bufferSize = bufferSize || 1024
     this.sock = dgram.createSocket('udp4')
-    this.sock.connect(this.port, this.host)
 
     const events = ['close', 'connect', 'error', 'message']
     for (let i = 0; i < events.length; i++) {
@@ -76,7 +75,7 @@ class Client extends EventEmitter {
       return
     }
 
-    this.sock.send(msg)
+    this.sock.send(msg, this.port, this.host)
   }
 
   /**
@@ -84,7 +83,7 @@ class Client extends EventEmitter {
    */
   flush() {
     if (this.buffer.length > 0) {
-      this.sock.send(this.buffer)
+      this.sock.send(this.buffer, this.port, this.host)
       this.buffer = ''
       this.emit('flush')
     }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.0",
   "repository": "segmentio/dog-statsy",
   "description": "dogstatsd client",
+  "scripts": {
+    "test": "nyc ava -v"
+  },
   "keywords": [
     "datadog",
     "dogstatsd",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dog-statsy",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "repository": "segmentio/dog-statsy",
   "description": "dogstatsd client",
   "scripts": {


### PR DESCRIPTION
This PR makes the package backward compatible with node 10, addressing this error:
```
    this.sock.connect(this.port, this.host)
              ^

TypeError: this.sock.connect is not a function
    at new Client (/Users/achille.roussel/dev/src/github.com/segmentio/integrations-engine/node_modules/dog-statsy/index.js:17:15)
```